### PR TITLE
Added terminals ':=' and '=>'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ebin
+aleppo_parser.erl

--- a/src/aleppo_parser.yrl
+++ b/src/aleppo_parser.yrl
@@ -40,7 +40,7 @@ Terminals
 
     char integer float atom string var
     '(' ')' ',' '-'
-    '->' ':-' '{' '}' '[' ']' '|' '||' '<-' ';' ':' '#' '.'
+    '->' ':-' '{' '}' '[' ']' '|' '||' '<-' ';' ':' '#' '.' ':=' '=>'
     'after' 'begin' 'case' 'try' 'catch' 'end' 'fun' 'if' 'of' 'receive' 'when'
     'andalso' 'orelse' 'query' 'spec'
     'bnot' 'not'
@@ -153,6 +153,8 @@ ExpressionToken -> ';' : '$1'.
 ExpressionToken -> ':' : '$1'.
 ExpressionToken -> '#' : '$1'.
 ExpressionToken -> '.' : '$1'.
+ExpressionToken -> ':=' : '$1'.
+ExpressionToken -> '=>' : '$1'.
 ExpressionToken -> 'after' : '$1'.
 ExpressionToken -> 'begin' : '$1'.
 ExpressionToken -> 'case' : '$1'.


### PR DESCRIPTION
Grammar definition was outdated and had some terminals missing related to maps, which were added.
